### PR TITLE
Restore bounds on jax versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install .[jax] -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -28,8 +28,9 @@ requirements:
     - multiset >=3.0.1
     - sympy >=1.12
     - arraylias
-    - jax
-    - jaxlib
+    - jax >=0.4.0,<=0.4.6
+    - jaxlib >=0.4.0,<=0.4.6
+
 
 test:
   imports:


### PR DESCRIPTION
The removal of the bounds on jax is only included in the next qiskit-dynamics release >=0.5. The bounds should not have been removed from the 0.4 series package.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
